### PR TITLE
New feature: fullscreen mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ one can have as many windows he wants.
 
 ---
 
- *Monocle mode* (aka fullscreen)
+ *Monocle mode* (aka maximized)
 
     -------------
     |           |
@@ -69,7 +69,7 @@ one can have as many windows he wants.
     |           |
     -------------
 
-`MONOCLE` layout presents one window at a time in fullscreen mode.
+`MONOCLE` layout presents one window at a time in maximized mode.
 Windows have no borders on this layout to save space.
 See the `monocleborders` branch to give those windows borders.
 
@@ -117,7 +117,7 @@ desktop and urgent hints whenever needed. The user can use whatever tool or
 panel suits him best (dzen2, conky, w/e), to process and display that information.
 
 To disable the panel completely set `PANEL_HEIGHT` to zero `0`.
-The `SHOW_PANELL` setting controls whether the panel is visible on startup,
+The `SHOW_PANEL` setting controls whether the panel is visible on startup,
 it does not control whether there is a panel or not.
 
   [unix]: http://en.wikipedia.org/wiki/Unix_philosophy
@@ -138,7 +138,7 @@ Do not be limited by those examples.
 Installation
 ------------
 
-You need Xlib, then,
+You need Xlib (there's an [xcb port](https://github.com/Cloudef/monsterwm-xcb)), then,
 copy `config.def.h` as `config.h`
 and edit to suit your needs.
 Build and install.
@@ -159,11 +159,11 @@ Easiest way to apply a patch, is to `git merge` that branch.
 Currently:
 
  * [centerwindow]   : center new floating windows on the screen and  center any window with a shortcut
- * [fibonacci]      : adds fibonacci layout mode
+ * [fibonacci]      : adds `fibonacci` layout mode
  * [initlayouts]    : define initial layouts for every desktop
  * [monocleborders] : adds borders to the monocle layout
- * [nmaster]        : adds nmaster layout - multiple master windows for BSTACK and TILE layouts
- * [rectangle]      : draws only a rectangle when moving/resizing windows to keep resources low (ie through an ssh forwarded session)
+ * [nmaster]        : adds `nmaster` layout - multiple master windows for BSTACK and TILE layouts
+ * [rectangle]      : draws only a rectangle when moving/resizing windows to keep resources low (i.e. through an ssh forwarded session)
  * [showhide]       : adds a function to show and hide all windows on all desktops
  * [uselessgaps]    : adds gaps around every window on screen
  * [warpcursor]     : cursors follows and is placed in the center of the current window

--- a/config.def.h
+++ b/config.def.h
@@ -57,6 +57,7 @@ static const char *menucmd[] = { "dmenu_run", NULL };
 static Key keys[] = {
     /* modifier          key            function           argument */
     {  MOD1,             XK_b,          togglepanel,       {NULL}},
+    {  MOD1,             XK_f,          togglefullscreen,  {NULL}},
     {  MOD1,             XK_BackSpace,  focusurgent,       {NULL}},
     {  MOD1|SHIFT,       XK_c,          killclient,        {NULL}},
     {  MOD1,             XK_j,          next_win,          {NULL}},

--- a/config.def.h
+++ b/config.def.h
@@ -57,7 +57,6 @@ static const char *menucmd[] = { "dmenu_run", NULL };
 static Key keys[] = {
     /* modifier          key            function           argument */
     {  MOD1,             XK_b,          togglepanel,       {NULL}},
-    {  MOD1,             XK_f,          togglefullscreen,  {NULL}},
     {  MOD1,             XK_BackSpace,  focusurgent,       {NULL}},
     {  MOD1|SHIFT,       XK_c,          killclient,        {NULL}},
     {  MOD1,             XK_j,          next_win,          {NULL}},
@@ -79,6 +78,7 @@ static Key keys[] = {
     {  MOD1|SHIFT,       XK_b,          switch_mode,       {.i = BSTACK}},
     {  MOD1|SHIFT,       XK_g,          switch_mode,       {.i = GRID}},
     {  MOD1|SHIFT,       XK_f,          switch_mode,       {.i = FLOAT}},
+    {  MOD1,             XK_f,          togglefullscreen,  {NULL}},
     {  MOD1|CONTROL,     XK_r,          quit,              {.i = 0}}, /* quit with exit value 0 */
     {  MOD1|CONTROL,     XK_q,          quit,              {.i = 1}}, /* quit with exit value 1 */
     {  MOD1|SHIFT,       XK_Return,     spawn,             {.com = termcmd}},

--- a/monsterwm.1
+++ b/monsterwm.1
@@ -24,15 +24,16 @@ the stack clients are tiled on the side of master.
 the stack clients are tiled beneath the master.
 .TP
 .B Grid mode
-clients are tiled in a grid, equaly sharing and dividing the screen space
+clients are tiled in a grid, equally sharing and dividing the screen space
 .TP
 .B Monocle mode
-also known as fullscreen or max mode, where the clients take up the entire
+also known as max mode, where the clients take up the entire
 screen space. Other clients are hidden behind the current shown window.
-On this layout, fullscreen clients don't need and don't have borders.
+On this layout, maximized clients don't need and don't have borders.
 You can change that behavior with the
 .I monocleborders
-patch, in the corresponding branch.
+patch, in the corresponding branch. The state of the panel is preserved.
+
 .TP
 .B Floating mode
 windows can move and be resized freely in the screen space, like on a stacking
@@ -48,7 +49,7 @@ prints version information to standard output, then exits.
 .I monsterwm
 does not provide a status bar. Consistent with the Unix philosophy,
 .I monsterwm
-provides information to the status bar or panel of choice via ouputing
+provides information to the status bar or panel of choice via outputting
 text with information about the state of the windows.
 .P
 the available settings in
@@ -141,8 +142,11 @@ Sets grid layout
 .B Mod1\-Shift\-f
 Sets float layout
 .TP
+.B Mod1\-f
+Toggles fullscreen mode
+.TP
 .B Mod1\-Shift\-r
-Quit with exit value 0 (usefull for restarts of the wm).
+Quit with exit value 0 (useful for restarts of the wm).
 .TP
 .B Mod1\-Shift\-q
 Quit with exit value 1 (differentiate quit from restart).
@@ -213,7 +217,7 @@ whether to focus the window the mouse just entered
 whether to follow the window to the new desktop where it moved
 .TP
 .B CLICK_TO_FOCUS
-whether an action on a window (eg clicking, or scrolling)
+whether an action on a window (e.g. clicking, or scrolling)
 will give the window focus. Disabling this gives the user
 the ability to, for example, look up things on a web browser
 but not lose focus from the terminal etc.
@@ -232,7 +236,7 @@ which desktop to focus by default
 .TP
 .B MINWSZ
 the minimum window size allowed. Prevents over resizing with
-the mouse or keyboard (eg resizing the master area)
+the mouse or keyboard (e.g. resizing the master area)
 .P
 users can set
 .B rules

--- a/monsterwm.c
+++ b/monsterwm.c
@@ -1170,6 +1170,10 @@ void swap_master(void) {
  */
 void switch_mode(const Arg *arg) {
     Desktop *d = &desktops[currdeskidx];
+    if (d->isfs) {
+        if (d->sbar != d->psbr) togglepanel();
+        d->isfs = False;
+    }
     if (d->mode != arg->i) d->mode = arg->i;
     else if (d->mode != FLOAT) for (Client *c = d->head; c; c = c->next) c->isfloat = False;
     if (d->head) { tile(d); focus(d->curr, d); }
@@ -1201,8 +1205,8 @@ void togglefullscreen(void) {
         if (d->sbar) togglepanel();
         d->pmod = d->mode;
         switch_mode(&(Arg){.i = MONOCLE});
+        d->isfs = True;
     }
-    d->isfs = !d->isfs;
 }
 
 /**

--- a/monsterwm.c
+++ b/monsterwm.c
@@ -783,7 +783,7 @@ void mousemotion(const Arg *arg) {
 }
 
 /**
- * monocle aka max aka fullscreen mode/layout
+ * monocle aka max(imized) mode/layout
  * each window should cover all the available screen space
  */
 void monocle(int x, int y, int w, int h, const Desktop *d) {

--- a/monsterwm.c
+++ b/monsterwm.c
@@ -133,12 +133,13 @@ typedef struct Client {
  * curr - the currently highlighted window
  * prev - the client that previously had focus
  * sbar - the visibility status of the panel/statusbar
- * psbr - its visibility before going into fullscreen mode
+ * psbr - its visibility status before going into fullscreen mode
+ * isfs - whether the desktop is in fullscreen mode
  */
 typedef struct {
     int mode, pmod, masz, sasz;
     Client *head, *curr, *prev;
-    Bool sbar, psbr, isfullscreen;
+    Bool sbar, psbr, isfs;
 } Desktop;
 
 /* hidden function prototypes sorted alphabetically */
@@ -1029,7 +1030,7 @@ void setup(void) {
 
     /* initialize mode and panel visibility for each desktop */
     for (unsigned int d = 0; d < DESKTOPS; d++)
-        desktops[d] = (Desktop){ .mode = DEFAULT_MODE, .sbar = SHOW_PANEL, .isfullscreen = False };
+        desktops[d] = (Desktop){ .mode = DEFAULT_MODE, .sbar = SHOW_PANEL, .isfs = False };
 
     /* get color for focused and unfocused client borders */
     win_focus = getcolor(FOCUS, screen);
@@ -1191,7 +1192,7 @@ void tile(Desktop *d) {
  */
 void togglefullscreen(void) {
     Desktop *d = &desktops[currdeskidx];
-    if (d->isfullscreen) {
+    if (d->isfs) {
         if (d->sbar != d->psbr) togglepanel();
         switch_mode(&(Arg){.i = d->pmod});
     }
@@ -1201,7 +1202,7 @@ void togglefullscreen(void) {
         d->pmod = d->mode;
         switch_mode(&(Arg){.i = MONOCLE});
     }
-    d->isfullscreen = !d->isfullscreen;
+    d->isfs = !d->isfs;
 }
 
 /**


### PR DESCRIPTION
Hi,

First of all, I want to thank you for monsterwm. I've been using it for some days now, and it's my favourite window manager so far (after years of using Ion, StumpWM and other tiling window managers) ☺

There's a feature I like which is on StumpWM but isn't on monsterwm: the ability to move to a fullscreen mode and return from it to the previous state with a single key binding. You can mimic this by using the monocle layout and then returning to the layout you used before, but this is not as easy as hitting `M-f` and then `M-f` again when you're done (and there's the issue of manually turning the bar off and on).
I use this feature a lot: when I need to do something in a window that requires the whole screen, I just pop in fullscreen mode, do whatever I need to, and than returning to the usual tiling layout.
This is very convenient IMHO, and I'd like to see this feature incorporated into the main branch of monsterwm, or at least given as a patch/branch on your repo.

This is my implementation of it, with some additional editing of the documentation.

Have a wonderful day,
Júda
